### PR TITLE
Change colors of playbar to be more readable

### DIFF
--- a/frappe.yml
+++ b/frappe.yml
@@ -2,9 +2,9 @@ theme:
   error_border: "231, 130, 132" # error dialog border is Red
   error_text: "234, 153, 156" # error message text (e.g. "Spotify API reported error 404") is Maroon
   hint: "229, 200, 144" # hint text in errors Yellow
-  playbar_background: "41, 44, 60" # background of progress bar "Mantle"
-  playbar_progress: "166, 209, 137" # filled-in part of the progress bar Green
-  playbar_progress_text: "165, 173, 206" # song length and time played/left indicator in the progress bar "Subtext 0"
+  playbar_background: "35, 38, 52" # background of progress bar "Crust"
+  playbar_progress: "41, 44, 60" # filled-in part of the progress bar Mantle
+  playbar_progress_text: "166, 209, 137" # song length and time played/left indicator in the progress bar "Green"
   playbar_text: "165, 173, 206" # artist name in player pane is "Subtext 0"
   inactive: "115, 121, 148" # borders of inactive panes "Overlay 0"
   text: "198, 208, 245" # text in panes is "Text"

--- a/latte.yml
+++ b/latte.yml
@@ -2,9 +2,9 @@ theme:
   error_border: "210, 15, 57" # error dialog border is Red
   error_text: "230, 69, 83" # error message text (e.g. "Spotify API reported error 404") is Maroon
   hint: "223, 142, 29" # hint text in errors Yellow
-  playbar_background: "230, 233, 239" # background of progress bar "Mantle"
-  playbar_progress: "64, 160, 43" # filled-in part of the progress bar Green
-  playbar_progress_text: "108, 111, 133" # song length and time played/left indicator in the progress bar "Subtext 0"
+  playbar_background: "220, 224, 232" # background of progress bar "Crust"
+  playbar_progress: "230, 233, 239" # filled-in part of the progress bar Mantle
+  playbar_progress_text: "64, 160, 43" # song length and time played/left indicator in the progress bar "Green"
   playbar_text: "108, 111, 133" # artist name in player pane is "Subtext 0"
   inactive: "124, 127, 147" # borders of inactive panes "Overlay 0"
   text: "76, 79, 105" # text in panes is "Text"

--- a/macchiato.yml
+++ b/macchiato.yml
@@ -2,9 +2,9 @@ theme:
   error_border: "237, 135, 150" # error dialog border is Red
   error_text: "238, 153, 160" # error message text (e.g. "Spotify API reported error 404") is Maroon
   hint: "238, 212, 159" # hint text in errors Yellow
-  playbar_background: "30, 32, 48" # background of progress bar "Mantle"
-  playbar_progress: "166, 218, 149" # filled-in part of the progress bar Green
-  playbar_progress_text: "165, 173, 203" # song length and time played/left indicator in the progress bar "Subtext 0"
+  playbar_background: "24, 25, 38" # background of progress bar "Crust"
+  playbar_progress: "30, 32, 48" # filled-in part of the progress bar Mantle
+  playbar_progress_text: "166, 218, 149" # song length and time played/left indicator in the progress bar "Green"
   playbar_text: "165, 173, 203" # artist name in player pane is "Subtext 0"
   inactive: "110, 115, 141" # borders of inactive panes "Overlay 0"
   text: "202, 211, 245" # text in panes is "Text"

--- a/mocha.yml
+++ b/mocha.yml
@@ -2,9 +2,9 @@ theme:
   error_border: "243, 139, 168" # error dialog border is Red
   error_text: "235, 160, 172" # error message text (e.g. "Spotify API reported error 404") is Maroon
   hint: "249, 226, 175" # hint text in errors Yellow
-  playbar_background: "24, 24, 37" # background of progress bar "Mantle"
-  playbar_progress: "166, 227, 161" # filled-in part of the progress bar Green
-  playbar_progress_text: "166, 173, 200" # song length and time played/left indicator in the progress bar "Subtext 0"
+  playbar_background: "17, 17, 27" # background of progress bar "Crust"
+  playbar_progress: "24, 24, 37" # filled-in part of the progress bar Mantle
+  playbar_progress_text: "166, 227, 161" # song length and time played/left indicator in the progress bar "Green"
   playbar_text: "166, 173, 200" # artist name in player pane is "Subtext 0"
   inactive: "108, 112, 134" # borders of inactive panes "Overlay 0"
   text: "205, 214, 244" # text in panes is "Text"


### PR DESCRIPTION
Previously, the playbar was Mantle with Green fill and Subtext 0 text. I like the splash of color this brings. Trouble is, I can't read Subtext 0 text on a Green background. 

My proposal is to change it to be Crust with Mantle fill and Green text. This significantly improves the readability of the text and maintains the colorfulness, but it does come at the expense of the filled in portion of the bar being slightly harder to distinguish from the not filled portion because of lower contrast. 

### Current playbar
![image](https://user-images.githubusercontent.com/46696318/219847542-a2ff31b6-bf16-44db-8d72-2cdf8de24d66.png)

### My proposal
![image](https://user-images.githubusercontent.com/46696318/219847530-d9333f7d-c68a-449b-bc2e-e0b071395ed1.png)
